### PR TITLE
Improve services page design and responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,7 +24,7 @@ body {
 }
 
 .navbar-toggler {
-    background-color: white;
+  background-color: white;
 }
 
 .navbar-custom .navbar-brand img {
@@ -54,7 +54,7 @@ body {
 /* Header section with background image */
 .header-section {
   position: relative;
-  background: url('../images/header.jpg') no-repeat center center/cover;
+  background: url("../images/header.jpg") no-repeat center center/cover;
   height: 60vh;
   display: flex;
   align-items: center;
@@ -208,7 +208,7 @@ body {
 
 /* Parallax section */
 .parallax-section {
-  background-image: url('../images/header.jpg');
+  background-image: url("../images/header.jpg");
   background-attachment: fixed;
   background-size: cover;
   background-position: center;
@@ -332,7 +332,9 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   padding: 20px;
   text-align: center;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .team-member:hover {
@@ -351,4 +353,190 @@ body {
 
 .team-member:hover img {
   transform: scale(1.05);
+}
+
+/* Services Page Styles */
+.service-header {
+  height: 40vh;
+}
+
+.hero {
+  margin-top: 22px;
+  border-radius: 20px;
+  background: linear-gradient(
+    135deg,
+    var(--secondary-color),
+    var(--primary-color)
+  );
+  color: #fff;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(1, 55, 83, 0.15);
+}
+
+.hero-inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+}
+
+.hero-copy {
+  padding: 30px;
+}
+
+.hero-title {
+  font-size: 2.5rem;
+  margin: 0 0 10px;
+  font-weight: 800;
+}
+
+.hero-sub {
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+.badge {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  display: inline-block;
+}
+
+.hero-img {
+  width: 100%;
+  max-height: 360px;
+  object-fit: cover;
+  border-radius: 20px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.our-service-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(1, 55, 83, 0.15);
+  margin-top: 14px;
+  color: var(--primary-color);
+  font-weight: 700;
+}
+
+.services {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.service {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 10px 30px rgba(1, 55, 83, 0.15);
+  text-align: center;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.service:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.service h3 {
+  margin: 10px 0 4px;
+  font-size: 1rem;
+  color: var(--secondary-color);
+}
+
+.service small {
+  color: #5f7ea5;
+}
+
+.service .icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  margin: 0 auto 8px;
+  background: linear-gradient(
+    135deg,
+    var(--secondary-color),
+    var(--primary-color)
+  );
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+
+.service .icon svg {
+  width: 28px;
+  height: 28px;
+  stroke: #fff;
+}
+
+/* Animal carousel styles */
+.animal-section ul {
+  margin-top: 1rem;
+}
+
+.animal-swiper {
+  padding-bottom: 10px;
+}
+
+.animal-swiper .swiper-slide {
+  width: auto;
+}
+
+.animal-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(1, 55, 83, 0.15);
+}
+
+.animal-card img {
+  width: 100%;
+  height: 350px;
+  object-fit: cover;
+}
+
+.animal-card .info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(
+    135deg,
+    var(--secondary-color),
+    var(--primary-color)
+  );
+  color: #fff;
+  padding: 12px;
+}
+
+.animal-card .info h4 {
+  margin: 0 0 4px;
+  font-size: 1rem;
+}
+
+.animal-card .info p {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  .hero-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-img {
+    margin-top: 20px;
+  }
+
+  .service-header {
+    height: 30vh;
+  }
 }

--- a/services.html
+++ b/services.html
@@ -1,435 +1,599 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Services | Ramji Oxyved</title>
-  <!-- Bootstrap CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <!-- Bootstrap Icons -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
-  <!-- Custom CSS -->
-  <link rel="stylesheet" href="css/style.css">
-  <!-- Swiper CSS for carousel -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css" />
-  
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&amp;display=swap" rel="stylesheet" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Services | Ramji Oxyved</title>
+    <!-- Bootstrap CSS -->
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <!-- Bootstrap Icons -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+    />
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="css/style.css" />
+    <!-- Swiper CSS for carousel -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css"
+    />
 
-  <style>
-       :root{
-      --blue-900:#0a4f9b;
-      --blue-800:#0b73c8;
-      --blue-700:#0a6fd3;
-      --blue-500:#3aa8e0;
-      --blue-200:#d8ecfb;
-      --blue-100:#eef7ff;
-      --text:#19324d;
-      --white:#ffffff;
-      --shadow:0 10px 30px rgba(10,79,155,.15);
-    }
-    *{box-sizing:border-box}
-     .brand{display:flex;align-items:center;gap:14px}
-    .logo{width:60px;height:60px;border-radius:50%;background:var(--blue-500);display:grid;place-items:center;box-shadow:var(--shadow)}
-    .brand h1{margin:0;font-weight:700;color:var(--blue-900);font-size:1.2rem}
-    .brand small{display:block;color:#4a7db3;font-weight:600}
-    .hero{margin-top:22px;border-radius:20px;background:linear-gradient(135deg,var(--blue-800),var(--blue-500));color:var(--white);overflow:hidden;box-shadow:var(--shadow)}
-    .hero-inner{display:grid;grid-template-columns:1fr 1fr;align-items:center}
-    .hero-copy{padding:30px}
-    .hero-title{font-size:2.5rem;margin:0 0 10px;font-weight:800}
-    .hero-sub{font-size:1rem;opacity:.9}
-    .badge{background:rgba(255,255,255,.2);padding:6px 12px;border-radius:999px;font-weight:600;margin-bottom:12px;display:inline-block}
-    .hero-img{width:100%;max-height:360px;object-fit:cover;border-radius:20px;box-shadow:0 10px 20px rgba(0,0,0,.25)}
-    .our-service-pill{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border-radius:999px;background:#fff;box-shadow:var(--shadow);margin-top:14px;color:var(--blue-800);font-weight:700}
-    .section{margin-top:40px}
-    .section h2{font-weight:800;color:var(--blue-900);font-size:1.6rem;margin-bottom:20px}
-    .services{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px}
-    .service{background:#fff;border-radius:12px;padding:16px;box-shadow:var(--shadow);text-align:center}
-    .service h3{margin:10px 0 4px;font-size:1rem;color:var(--blue-900)}
-    .service small{color:#5f7ea5}
-    .footer{text-align:center;margin:30px 0;color:#5a7aa3;font-size:.9rem}
-.service .icon{width:56px;height:56px;border-radius:50%;display:grid;place-items:center;margin:0 auto 8px;background:linear-gradient(135deg,var(--blue-700),var(--blue-500));box-shadow:inset 0 0 0 2px rgba(255,255,255,.35)}.service .icon svg{width:28px;height:28px;stroke:#fff}
-
-    /* Animal carousel styles */
-    .animal-section ul{margin-top:1rem}
-    .animal-swiper{padding-bottom:10px}
-    .animal-swiper .swiper-slide{width:auto}
-    .animal-card{position:relative;overflow:hidden;border-radius:12px;box-shadow:var(--shadow)}
-    .animal-card img{width:100%;height:350px;object-fit:cover}
-    .animal-card .info{position:absolute;bottom:0;left:0;right:0;background:linear-gradient(135deg,var(--blue-800),var(--blue-500));color:var(--white);padding:12px}
-    .animal-card .info h4{margin:0 0 4px;font-size:1rem}
-    .animal-card .info p{margin:0;font-size:.85rem}
-
-  </style>
-</head>
-<body>
-  <!-- Navigation -->
-  <nav class="navbar navbar-expand-lg navbar-custom fixed-top">
-    <div class="container">
-      <a class="navbar-brand" href="index.html">
-        <img src="images/logo.png" alt="Ramji Oxyved Logo">
-      </a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon" style="color:#ffffff;"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About Us</a></li>
-          <li class="nav-item"><a class="nav-link" href="products.html">Products</a></li>
-          <li class="nav-item"><a class="nav-link active" aria-current="page" href="services.html">Services</a></li>
-          <li class="nav-item"><a class="nav-link" href="hbot.html">HBOT</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.php">Contact Us</a></li>
-        </ul>
-      </div>
-    </div>
-  </nav>
-
-  <!-- Page Header -->
-  <section class="d-flex align-items-center justify-content-center" style="background: url('images/header.jpg') no-repeat center center/cover; height: 40vh; margin-top: 56px; position: relative;">
-    <div style="background-color: rgba(1,55,83,0.55); width: 100%; height: 100%; display:flex; align-items:center; justify-content:center;">
-      <h1 class="text-white display-4">Our Services</h1>
-    </div>
-  </section>
-
-
-  <!-- Services Content -->
-  <section class="section" id="services-content">
-    <div class="container">
-      <h2 class="section-title">Our Comprehensive Services</h2>
-      <div class="row g-4">
-        <!-- Card 1 -->
-        <div class="col-sm-6 col-lg-3">
-          <div class="flip-card h-100">
-            <div class="flip-card-inner">
-              <div class="flip-card-front">
-                <i class="bi bi-hospital flip-icon"></i>
-                <h5>Clinical Solutions</h5>
-                <p class="text-center">Dedicated to clinics & wellness centers</p>
-              </div>
-              <div class="flip-card-back">
-                <h5>Clinical Solutions</h5>
-                <p class="mb-1">Clinics & Hospitals</p>
-                <p class="mb-1">Wellness Centers</p>
-                <p class="mb-0">Sports Therapy Units</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Card 2 -->
-        <div class="col-sm-6 col-lg-3">
-          <div class="flip-card h-100">
-            <div class="flip-card-inner">
-              <div class="flip-card-front">
-                <i class="bi bi-activity flip-icon"></i>
-                <h5>Industrial & Diving</h5>
-                <p class="text-center">Solutions for industrial & diving needs</p>
-              </div>
-              <div class="flip-card-back">
-                <h5>Industrial & Diving</h5>
-                <p class="mb-0">Diving & Industrial Applications</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Card 3 -->
-        <div class="col-sm-6 col-lg-3">
-          <div class="flip-card h-100">
-            <div class="flip-card-inner">
-              <div class="flip-card-front">
-                <i class="bi bi-pencil-square flip-icon"></i>
-                <h5>Design & Consultation</h5>
-                <p class="text-center">Custom chamber design & guidance</p>
-              </div>
-              <div class="flip-card-back">
-                <h5>Design & Consultation</h5>
-                <p class="mb-1">Custom chamber design & development</p>
-                <p class="mb-0">Turnkey installation & consultation</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Card 4 -->
-        <div class="col-sm-6 col-lg-3">
-          <div class="flip-card h-100">
-            <div class="flip-card-inner">
-              <div class="flip-card-front">
-                <i class="bi bi-tools flip-icon"></i>
-                <h5>Maintenance & Training</h5>
-                <p class="text-center">Care for your HBOT systems</p>
-              </div>
-              <div class="flip-card-back">
-                <h5>Maintenance & Training</h5>
-                <p class="mb-1">Annual Maintenance Contracts</p>
-                <p class="mb-1">Complete turnkey solutions</p>
-                <p class="mb-0">Onsite operational training</p>
-              </div>
-            </div>
-          </div>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-custom fixed-top">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">
+          <img src="images/logo.png" alt="Ramji Oxyved Logo" />
+        </a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarNav"
+          aria-controls="navbarNav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon" style="color: #ffffff"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="index.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="about.html">About Us</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="products.html">Products</a>
+            </li>
+            <li class="nav-item">
+              <a
+                class="nav-link active"
+                aria-current="page"
+                href="services.html"
+                >Services</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="hbot.html">HBOT</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="contact.php">Contact Us</a>
+            </li>
+          </ul>
         </div>
       </div>
-    </div>
-  </section>
+    </nav>
 
+    <!-- Page Header -->
+    <header
+      class="header-section service-header d-flex align-items-center justify-content-center"
+    >
+      <div class="header-content">
+        <h1>Our Services</h1>
+      </div>
+    </header>
 
-  <main class="container">
-    <section class="hero" role="banner">
-      <div class="hero-inner">
-        <div class="hero-copy">
-          <span class="badge">Rehabilitation</span>
-          <h2 class="hero-title">REHABILITATION</h2>
-          <p class="hero-sub">Personalized recovery programs guided by expert therapists to help you regain mobility, strength and confidence.</p>
-          <div class="our-service-pill" aria-label="Our services">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--blue-800)"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-            <span>Our Services</span>
+    <!-- Services Content -->
+    <section class="section" id="services-content">
+      <div class="container">
+        <h2 class="section-title">Our Comprehensive Services</h2>
+        <div class="row g-4">
+          <!-- Card 1 -->
+          <div class="col-sm-6 col-lg-3">
+            <div class="flip-card h-100">
+              <div class="flip-card-inner">
+                <div class="flip-card-front">
+                  <i class="bi bi-hospital flip-icon"></i>
+                  <h5>Clinical Solutions</h5>
+                  <p class="text-center">
+                    Dedicated to clinics & wellness centers
+                  </p>
+                </div>
+                <div class="flip-card-back">
+                  <h5>Clinical Solutions</h5>
+                  <p class="mb-1">Clinics & Hospitals</p>
+                  <p class="mb-1">Wellness Centers</p>
+                  <p class="mb-0">Sports Therapy Units</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Card 2 -->
+          <div class="col-sm-6 col-lg-3">
+            <div class="flip-card h-100">
+              <div class="flip-card-inner">
+                <div class="flip-card-front">
+                  <i class="bi bi-activity flip-icon"></i>
+                  <h5>Industrial & Diving</h5>
+                  <p class="text-center">
+                    Solutions for industrial & diving needs
+                  </p>
+                </div>
+                <div class="flip-card-back">
+                  <h5>Industrial & Diving</h5>
+                  <p class="mb-0">Diving & Industrial Applications</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Card 3 -->
+          <div class="col-sm-6 col-lg-3">
+            <div class="flip-card h-100">
+              <div class="flip-card-inner">
+                <div class="flip-card-front">
+                  <i class="bi bi-pencil-square flip-icon"></i>
+                  <h5>Design & Consultation</h5>
+                  <p class="text-center">Custom chamber design & guidance</p>
+                </div>
+                <div class="flip-card-back">
+                  <h5>Design & Consultation</h5>
+                  <p class="mb-1">Custom chamber design & development</p>
+                  <p class="mb-0">Turnkey installation & consultation</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Card 4 -->
+          <div class="col-sm-6 col-lg-3">
+            <div class="flip-card h-100">
+              <div class="flip-card-inner">
+                <div class="flip-card-front">
+                  <i class="bi bi-tools flip-icon"></i>
+                  <h5>Maintenance & Training</h5>
+                  <p class="text-center">Care for your HBOT systems</p>
+                </div>
+                <div class="flip-card-back">
+                  <h5>Maintenance & Training</h5>
+                  <p class="mb-1">Annual Maintenance Contracts</p>
+                  <p class="mb-1">Complete turnkey solutions</p>
+                  <p class="mb-0">Onsite operational training</p>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-
       </div>
     </section>
 
-   <section class="section mb-4" aria-labelledby="services-title">
-      <h2 id="services-title">Our Service</h2>
-      <div class="services mt-5">
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M12 3v18"/>
-              <rect x="9.5" y="5" width="5" height="2" rx="1" fill="white"/>
-              <rect x="9.5" y="9" width="5" height="2" rx="1" fill="white"/>
-              <rect x="9.5" y="13" width="5" height="2" rx="1" fill="white"/>
-              <rect x="9.5" y="17" width="5" height="2" rx="1" fill="white"/>
-            </svg>
+    <main class="container">
+      <section class="hero" role="banner">
+        <div class="hero-inner">
+          <div class="hero-copy">
+            <span class="badge">Rehabilitation</span>
+            <h2 class="hero-title">REHABILITATION</h2>
+            <p class="hero-sub">
+              Personalized recovery programs guided by expert therapists to help
+              you regain mobility, strength and confidence.
+            </p>
+            <div class="our-service-pill" aria-label="Our services">
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="color: var(--primary-color)"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+              <span>Our Services</span>
+            </div>
           </div>
-          <h3>Spine Care</h3><small>Posture & back pain rehab</small>
         </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="8" cy="12" r="3"/>
-              <circle cx="16" cy="12" r="3"/>
-              <path d="M11 12h2"/>
-            </svg>
+      </section>
+
+      <section class="section mb-4" aria-labelledby="services-title">
+        <h2 id="services-title">Our Service</h2>
+        <div class="services mt-5">
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 3v18" />
+                <rect x="9.5" y="5" width="5" height="2" rx="1" fill="white" />
+                <rect x="9.5" y="9" width="5" height="2" rx="1" fill="white" />
+                <rect x="9.5" y="13" width="5" height="2" rx="1" fill="white" />
+                <rect x="9.5" y="17" width="5" height="2" rx="1" fill="white" />
+              </svg>
+            </div>
+            <h3>Spine Care</h3>
+            <small>Posture & back pain rehab</small>
           </div>
-          <h3>Ortho Care</h3><small>Joints, knee & shoulder</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M4 14l10-10"/>
-              <path d="M6 6l12 12"/>
-              <rect x="3" y="13" width="8" height="4" rx="1"/>
-              <rect x="13" y="7" width="8" height="4" rx="1"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="8" cy="12" r="3" />
+                <circle cx="16" cy="12" r="3" />
+                <path d="M11 12h2" />
+              </svg>
+            </div>
+            <h3>Ortho Care</h3>
+            <small>Joints, knee & shoulder</small>
           </div>
-          <h3>Sports Injury</h3><small>Return-to-play programs</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="3" y="11" width="18" height="4" rx="1"/>
-              <line x1="6" y1="15" x2="6" y2="20"/>
-              <line x1="18" y1="15" x2="18" y2="20"/>
-              <circle cx="8.5" cy="9" r="1.5" fill="white"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 14l10-10" />
+                <path d="M6 6l12 12" />
+                <rect x="3" y="13" width="8" height="4" rx="1" />
+                <rect x="13" y="7" width="8" height="4" rx="1" />
+              </svg>
+            </div>
+            <h3>Sports Injury</h3>
+            <small>Return-to-play programs</small>
           </div>
-          <h3>Physio Therapy</h3><small>Manual & exercise therapy</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M6 14h12l-1 5H7l-1-5z"/>
-              <path d="M8 14V9a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v5"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="3" y="11" width="18" height="4" rx="1" />
+                <line x1="6" y1="15" x2="6" y2="20" />
+                <line x1="18" y1="15" x2="18" y2="20" />
+                <circle cx="8.5" cy="9" r="1.5" fill="white" />
+              </svg>
+            </div>
+            <h3>Physio Therapy</h3>
+            <small>Manual & exercise therapy</small>
           </div>
-          <h3>Kegel EMS Chair</h3><small>Pelvic floor therapy</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="8" cy="8" r="2"/>
-              <path d="M4 20l2-6 4-2 2 2 4 1 2 5"/>
-              <circle cx="16" cy="9" r="2"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M6 14h12l-1 5H7l-1-5z" />
+                <path d="M8 14V9a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v5" />
+              </svg>
+            </div>
+            <h3>Kegel EMS Chair</h3>
+            <small>Pelvic floor therapy</small>
           </div>
-          <h3>Elder Care</h3><small>Geriatric physiotherapy</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M7 12a5 5 0 0 1 10 0v2a3 3 0 0 1-3 3h-2a3 3 0 0 1-3-3v-2"/>
-              <circle cx="9" cy="12" r=".8" fill="white"/>
-              <circle cx="12" cy="10" r=".8" fill="white"/>
-              <circle cx="15" cy="12" r=".8" fill="white"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="8" cy="8" r="2" />
+                <path d="M4 20l2-6 4-2 2 2 4 1 2 5" />
+                <circle cx="16" cy="9" r="2" />
+              </svg>
+            </div>
+            <h3>Elder Care</h3>
+            <small>Geriatric physiotherapy</small>
           </div>
-          <h3>Neuro Care</h3><small>Stroke & neuro rehab</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M7 16c0-3 2-6 5-6s5 3 5 6"/>
-              <rect x="6" y="16" width="12" height="3" rx="1"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M7 12a5 5 0 0 1 10 0v2a3 3 0 0 1-3 3h-2a3 3 0 0 1-3-3v-2"
+                />
+                <circle cx="9" cy="12" r=".8" fill="white" />
+                <circle cx="12" cy="10" r=".8" fill="white" />
+                <circle cx="15" cy="12" r=".8" fill="white" />
+              </svg>
+            </div>
+            <h3>Neuro Care</h3>
+            <small>Stroke & neuro rehab</small>
           </div>
-          <h3>Vacuum Therapy</h3><small>Negative pressure therapy</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M8 12a4 4 0 1 1 8 0v2H8z"/>
-              <path d="M10 14v2m4-2v2"/>
-              <path d="M7 10h2m6 0h2"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M7 16c0-3 2-6 5-6s5 3 5 6" />
+                <rect x="6" y="16" width="12" height="3" rx="1" />
+              </svg>
+            </div>
+            <h3>Vacuum Therapy</h3>
+            <small>Negative pressure therapy</small>
           </div>
-          <h3>Autism Care</h3><small>Early support programs</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M4 12c0-3.3 2.7-6 6-6h2a6 6 0 1 1 0 12h-2l-4 2v-2a6 6 0 0 1-2-6z"/>
-              <path d="M16 10c.8.4 1.2 1 1.2 2S16.8 13.6 16 14"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M8 12a4 4 0 1 1 8 0v2H8z" />
+                <path d="M10 14v2m4-2v2" />
+                <path d="M7 10h2m6 0h2" />
+              </svg>
+            </div>
+            <h3>Autism Care</h3>
+            <small>Early support programs</small>
           </div>
-          <h3>Speech Therapy</h3><small>Voice & communication</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="10" r="3"/>
-              <path d="M6 20c1.5-2.5 4-4 6-4s4.5 1.5 6 4"/>
-              <path d="M11 9h2"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M4 12c0-3.3 2.7-6 6-6h2a6 6 0 1 1 0 12h-2l-4 2v-2a6 6 0 0 1-2-6z"
+                />
+                <path d="M16 10c.8.4 1.2 1 1.2 2S16.8 13.6 16 14" />
+              </svg>
+            </div>
+            <h3>Speech Therapy</h3>
+            <small>Voice & communication</small>
           </div>
-          <h3>Pediatric Care</h3><small>Child-focused rehab</small>
-        </div>
-        <div class="service">
-          <div class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M6 14v-2a3 3 0 0 1 6 0v2"/>
-              <path d="M12 14v-1a3 3 0 0 1 6 0v2"/>
-              <path d="M6 14c0 2 1.6 4 4 4h4c2.4 0 4-2 4-4"/>
-              <path d="M10 7h.01M14 7h.01"/>
-            </svg>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="10" r="3" />
+                <path d="M6 20c1.5-2.5 4-4 6-4s4.5 1.5 6 4" />
+                <path d="M11 9h2" />
+              </svg>
+            </div>
+            <h3>Pediatric Care</h3>
+            <small>Child-focused rehab</small>
           </div>
-          <h3>Occupational Therapy</h3><small>Daily living skills</small>
+          <div class="service">
+            <div class="icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M6 14v-2a3 3 0 0 1 6 0v2" />
+                <path d="M12 14v-1a3 3 0 0 1 6 0v2" />
+                <path d="M6 14c0 2 1.6 4 4 4h4c2.4 0 4-2 4-4" />
+                <path d="M10 7h.01M14 7h.01" />
+              </svg>
+            </div>
+            <h3>Occupational Therapy</h3>
+            <small>Daily living skills</small>
+          </div>
         </div>
+      </section>
+
+      <!-- Animal Hyperbaric Oxygen Chambers Section -->
+      <section class="section animal-section" id="animal-chambers">
+        <div class="container">
+          <h2>Animal Hyperbaric Oxygen Chambers</h2>
+          <p>
+            At Ramji Oxyved Private Limited, we don’t just design and
+            manufacture world-class Hyperbaric Oxygen Therapy (HBOT) chambers
+            for humans; we also specialize in creating customized chambers for
+            animals. Our expertise in precision engineering and medical-grade
+            fabrication allows us to design and deliver chambers that cater to
+            the unique requirements of various animals, ensuring safety,
+            comfort, and healing efficiency.
+          </p>
+
+          <h3 class="mt-4">Our Specialized Animal Chambers</h3>
+          <div class="swiper animal-swiper mt-3">
+            <div class="swiper-wrapper">
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-elephant.png" alt="Elephants" />
+
+                  <div class="info">
+                    <h4>Elephants</h4>
+                    <p>
+                      Large, reinforced chambers for veterinary hospitals and
+                      conservation centers
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-lion.png" alt="Lions and Wild Cats" />
+                  <div class="info">
+                    <h4>Lions & Wild Cats</h4>
+                    <p>
+                      Tailored oxygen chambers for big cats and exotic predators
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-dog.png" alt="Dogs and Cats" />
+                  <div class="info">
+                    <h4>Dogs & Cats</h4>
+                    <p>
+                      Compact, easy-to-operate chambers for small and
+                      medium-sized animals
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-horse.png" alt="Horses" />
+                  <div class="info">
+                    <h4>Horses</h4>
+                    <p>
+                      Equine-specific, comfortable chambers for veterinary
+                      clinics and sports facilities
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-bird.png" alt="Birds" />
+                  <div class="info">
+                    <h4>Birds</h4>
+                    <p>
+                      Specially designed enclosures for small and delicate
+                      species
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-pyramid.png" alt="Pyramids" />
+                  <div class="info">
+                    <h4>Pyramids</h4>
+                    <p>
+                      Uniquely designed energy-healing pyramids with natural
+                      aesthetics
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="swiper-slide">
+                <div class="animal-card">
+                  <img src="images/animal-small.png" alt="Sports Animals" />
+                  <div class="info">
+                    <h4>Other Small Animals</h4>
+                    <p>
+                      rabbits, guinea pigs, and exotic pets with specialized
+                      tray and sitting space.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <h3 class="mt-4">Why Choose Ramji Oxyved for Animal Chambers?</h3>
+          <ul>
+            <li>
+              <strong>Custom Design</strong> – Every chamber is engineered as
+              per the size, weight, and comfort needs of the animal.
+            </li>
+            <li>
+              <strong>Veterinary Collaboration</strong> – Designs developed in
+              consultation with veterinary specialists.
+            </li>
+            <li>
+              <strong>Durability & Safety</strong> – Built to withstand
+              high-pressure oxygen treatment with advanced safety protocols.
+            </li>
+            <li>
+              <strong>Global Reach</strong> – Supplying to veterinary hospitals,
+              zoos, sanctuaries, and research centers worldwide.
+            </li>
+          </ul>
+          <p class="mt-3">
+            With our dedication to innovation and animal welfare, Ramji Oxyved
+            Pvt. Ltd. continues to set new benchmarks in HBOT technology for
+            veterinary and wildlife care.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <!-- Parallax Callout Section -->
+    <section class="parallax-section">
+      <div class="parallax-content">
+        <h2>Partner with Experts</h2>
+        <p>
+          Let our experienced team guide you through every stage of design,
+          installation and maintenance of your HBOT systems.
+        </p>
+        <a href="contact.php" class="button-theme mt-3">Discuss Your Project</a>
       </div>
-  </section>
+    </section>
 
-  <!-- Animal Hyperbaric Oxygen Chambers Section -->
-  <section class="section animal-section" id="animal-chambers">
-    <div class="container">
-      <h2>Animal Hyperbaric Oxygen Chambers</h2>
-      <p>At Ramji Oxyved Private Limited, we don’t just design and manufacture world-class Hyperbaric Oxygen Therapy (HBOT) chambers for humans; we also specialize in creating customized chambers for animals. Our expertise in precision engineering and medical-grade fabrication allows us to design and deliver chambers that cater to the unique requirements of various animals, ensuring safety, comfort, and healing efficiency.</p>
-
-      <h3 class="mt-4">Our Specialized Animal Chambers</h3>
-      <div class="swiper animal-swiper mt-3">
-        <div class="swiper-wrapper">
-          <div class="swiper-slide">
-            <div class="animal-card">
-
-              <img src="images/animal-elephant.png" alt="Elephants">
-              
-              <div class="info">
-                <h4>Elephants</h4>
-                <p>Large, reinforced chambers for veterinary hospitals and conservation centers</p>
-              </div>
-            </div>
-          </div>
-          <div class="swiper-slide">
-            <div class="animal-card">
-              <img src="images/animal-lion.png" alt="Lions and Wild Cats">
-                <div class="info">
-                <h4>Lions & Wild Cats</h4>
-                <p>Tailored oxygen chambers for big cats and exotic predators</p>
-              </div>
-            </div>
-          </div>
-          <div class="swiper-slide">
-            <div class="animal-card">
-              <img src="images/animal-dog.png" alt="Dogs and Cats">
-              <div class="info">
-                <h4>Dogs & Cats</h4>
-                <p>Compact, easy-to-operate chambers for small and medium-sized animals</p>
-              </div>
-            </div>
-          </div>
-          <div class="swiper-slide">
-            <div class="animal-card">
-              <img src="images/animal-horse.png" alt="Horses">
-              <div class="info">
-                <h4>Horses</h4>
-                <p>Equine-specific, comfortable chambers for veterinary clinics and sports facilities</p>
-              </div>
-            </div>
-          </div>
-          <div class="swiper-slide">
-            <div class="animal-card">
-              <img src="images/animal-bird.png" alt="Birds">
-              <div class="info">
-                <h4>Birds</h4>
-                <p>Specially designed enclosures for small and delicate species</p>
-              </div>
-            </div>
-          </div>
-          <div class="swiper-slide">
-            <div class="animal-card">
-              <img src="images/animal-pyramid.png" alt="Pyramids">
-              <div class="info">
-                <h4>Pyramids</h4>
-                <p>Uniquely designed energy-healing pyramids with natural aesthetics</p>
-              </div>
-            </div>
-          </div>
-          <div class="swiper-slide">
-            <div class="animal-card">
-              <img src="images/animal-small.png" alt="Sports Animals">
-              <div class="info">
-                <h4>Other Small Animals</h4>
-                <p>rabbits, guinea pigs, and exotic pets with specialized tray and sitting space.</p>
-              </div>
-            </div>
-          </div>
-        </div>
+    <!-- Footer -->
+    <footer class="footer">
+      <div class="container">
+        <p class="mb-2">
+          &copy; 2025 Ramji Oxyved Pvt. Ltd. All rights reserved.
+        </p>
+        <p class="small">
+          Designed with care to promote better health and healing.
+        </p>
       </div>
+    </footer>
 
-      <h3 class="mt-4">Why Choose Ramji Oxyved for Animal Chambers?</h3>
-      <ul>
-        <li><strong>Custom Design</strong> – Every chamber is engineered as per the size, weight, and comfort needs of the animal.</li>
-        <li><strong>Veterinary Collaboration</strong> – Designs developed in consultation with veterinary specialists.</li>
-        <li><strong>Durability & Safety</strong> – Built to withstand high-pressure oxygen treatment with advanced safety protocols.</li>
-        <li><strong>Global Reach</strong> – Supplying to veterinary hospitals, zoos, sanctuaries, and research centers worldwide.</li>
-      </ul>
-      <p class="mt-3">With our dedication to innovation and animal welfare, Ramji Oxyved Pvt. Ltd. continues to set new benchmarks in HBOT technology for veterinary and wildlife care.</p>
-    </div>
-  </section>
-
-  </main>
-  
-  <!-- Parallax Callout Section -->
-  <section class="parallax-section">
-    <div class="parallax-content">
-      <h2>Partner with Experts</h2>
-      <p>Let our experienced team guide you through every stage of design, installation and maintenance of your HBOT systems.</p>
-      <a href="contact.php" class="button-theme mt-3">Discuss Your Project</a>
-    </div>
-  </section>
-
-  <!-- Footer -->
-  <footer class="footer">
-    <div class="container">
-      <p class="mb-2">&copy; 2025 Ramji Oxyved Pvt. Ltd. All rights reserved.</p>
-      <p class="small">Designed with care to promote better health and healing.</p>
-    </div>
-  </footer>
-
-  <!-- Bootstrap JS -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- Swiper JS -->
-  <script src="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js"></script>
-  <!-- Custom JS -->
-  <script src="js/script.js"></script>
-</body>
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Swiper JS -->
+    <script src="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js"></script>
+    <!-- Custom JS -->
+    <script src="js/script.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Move services page inline styles into shared stylesheet with site theme
- Redesign services header and service grid with responsive, hover-enabled cards
- Add mobile-friendly media queries and unified color scheme

## Testing
- `npx prettier --write services.html css/style.css`


------
https://chatgpt.com/codex/tasks/task_e_68ab623e7acc83238b187af692c10e57