### PR TITLE
Revamp team section with timeline layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -66,8 +66,8 @@
   <section class="section" id="team">
     <div class="container">
       <h2 class="section-title">Our Team Members</h2>
-      <div class="row g-4">
-        <div class="col-sm-6 col-md-4">
+      <div class="timeline">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Mr. Ram Suhag">
             <h5 class="mt-3">Mr. Ram Suhag <h6>(Rtd. Indian Navy, Exp – 35 years)</h6></h5>
@@ -75,7 +75,7 @@
             <p class="small">With 35 years of distinguished service in the Indian Navy as a Deep-Sea Diver Instructor, he brings deep expertise in operating and managing deep diving chambers and medical-grade HBOT systems. He is responsible for project execution, strategic planning, and effective communication with stakeholders. His vision is to revolutionize healthcare by advancing the use of HBOT technology.</p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Mr. Mukesh Gupta">
             <h5 class="mt-3">Mr. Mukesh Gupta<h6>(Manufacturers Association, Ex-Counsellors of MSMED ACT, Exp – 45 years)</h6></h5>
@@ -83,7 +83,7 @@
             <p class="small">He has 45 years of experience. He leads the manufacturing of HBOT chambers, overseeing fabrication, assembly, and quality control to ensure each unit meets medical-grade standards.</p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Wg Cdr J K Pathak (Retd)">
             <h5 class="mt-3">Wg Cdr J K Pathak (Retd) <h6>(Exp-30 years)</h6></h5>
@@ -91,7 +91,7 @@
             <p class="small">He has 30 years of experience in Air operations and corporate affairs. He looks after business development, marketing and sales. </p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Ms. Vandana Suhag">
             <h5 class="mt-3">Ms. Vandana Suhag <h6>(Administrator, Exp-10 years)</h6></h5>
@@ -99,7 +99,7 @@
             <p class="small">She has 10 years of experience in administration, managing documentation, compliance, and internal coordination. She ensures smooth daily operations and efficient workflow across departments. Her expertise supports seamless organizational functioning and regulatory alignment.</p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Mr. Shiv Ptiash">
             <h5 class="mt-3">Mr. Hitesh Gupta <h6>(Exp-10 years)</h6></h5>
@@ -107,7 +107,7 @@
             <p class="small">He has 10 years of experience and oversees day-to-day operations, internal coordination, and administrative processes to ensure smooth and efficient functioning across all departments.</p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Mr. Ram Prakash">
             <h5 class="mt-3">Mr. Ram Prakash<h6>(Exp-12 years)</h6></h5>
@@ -115,7 +115,7 @@
             <p class="small">He brings over 12 years of experience and leads the technical operations, innovation initiatives, and system design of our HBOT chambers—ensuring that every unit meets the highest standards of engineering precision, safety, and industry compliance.</p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Mr. Nitesh Gupta">
             <h5 class="mt-3">Mr. Nitesh Gupta <h6>(Exp-12 years)</h6></h5>
@@ -123,7 +123,7 @@
             <p class="small">He has 12 years of experience in engineering and technical operations. As Technical Director, he oversees projects and ensures all documentation is accurate and compliant. This ensures smooth operations and adherence to industry standards.</p>
           </div>
         </div>
-        <div class="col-sm-6 col-md-4">
+        <div class="timeline-item">
           <div class="team-member">
             <img src="images/team-placeholder.svg" alt="Mrs. Supriya Suhag">
             <h5 class="mt-3">Mrs. Supriya Suhag<h6>(Exp-8 years)</h6></h5>

--- a/css/style.css
+++ b/css/style.css
@@ -355,6 +355,74 @@ body {
   transform: scale(1.05);
 }
 
+/* Timeline layout for team section */
+.timeline {
+  position: relative;
+  padding: 2rem 0;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 4px;
+  background-color: var(--primary-color);
+  transform: translateX(-50%);
+}
+
+.timeline-item {
+  position: relative;
+  width: 50%;
+  padding: 1rem 2rem;
+}
+
+.timeline-item:nth-child(even) {
+  margin-left: 50%;
+}
+
+.timeline-item:nth-child(odd) {
+  text-align: right;
+}
+
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  top: 20px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--primary-color);
+  border: 4px solid var(--light-color);
+  z-index: 1;
+}
+
+.timeline-item:nth-child(odd)::before {
+  right: -10px;
+}
+
+.timeline-item:nth-child(even)::before {
+  left: -10px;
+}
+
+@media (max-width: 768px) {
+  .timeline::before {
+    left: 8px;
+  }
+  .timeline-item {
+    width: 100%;
+    padding-left: 2.5rem;
+    padding-right: 0;
+    margin-left: 0;
+    text-align: left;
+  }
+  .timeline-item::before {
+    left: 0;
+    right: auto;
+  }
+}
+
 /* Services Page Styles */
 .service-header {
   height: 40vh;


### PR DESCRIPTION
## Summary
- Present team members on about page in a vertical timeline for a more creative introduction.
- Add custom CSS to render the timeline with alternating positions and responsive behavior.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade10d1adc8323a11ed9d5f6e454b8